### PR TITLE
Base power-up system

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,10 @@ run/size/viewport_height=648
 run/size/viewport_width=1152
 run/handheld/orientation=0
 
+[autoload]
+
+GameState="*uid://dalnv4ctvosjo"
+
 [display]
 
 window/size/viewport_width=648

--- a/scenes/game_state.tscn
+++ b/scenes/game_state.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3 uid="uid://dalnv4ctvosjo"]
+
+[ext_resource type="Script" uid="uid://bndwnnyg3hghw" path="res://scripts/game_state.gd" id="1_321hb"]
+
+[node name="GameState" type="Node" unique_id=23191891]
+script = ExtResource("1_321hb")

--- a/scenes/grid.tscn
+++ b/scenes/grid.tscn
@@ -2,8 +2,8 @@
 
 [ext_resource type="Script" uid="uid://cge00dc8ok2no" path="res://scripts/grid.gd" id="1_65i6o"]
 [ext_resource type="Texture2D" uid="uid://dfl3tfhhgl2ro" path="res://assets/grid.png" id="1_ebq2e"]
-[ext_resource type="Texture2D" uid="uid://bbevgroje2xhq" path="res://assets/ok.png" id="3_sle3t"]
-[ext_resource type="Texture2D" uid="uid://da1qyajbahw8k" path="res://assets/no.png" id="4_bghhw"]
+[ext_resource type="Texture2D" uid="uid://gkrx4ajjr02k" path="res://assets/ok.png" id="3_sle3t"]
+[ext_resource type="Texture2D" uid="uid://b6v2wtvpo76bb" path="res://assets/no.png" id="4_bghhw"]
 
 [node name="Grid" type="Node2D" unique_id=1919714740]
 script = ExtResource("1_65i6o")

--- a/scripts/game_state.gd
+++ b/scripts/game_state.gd
@@ -1,0 +1,15 @@
+extends Node
+
+
+signal points_changed
+
+@export_group("Level")
+@export var level: int
+@export var points: int:
+	set(value):
+		points = value
+		points_changed.emit()
+@export var secret_word: String
+@export_group("Player")
+@export var coins: int
+@export var power_ups: Array[PowerUp]

--- a/scripts/game_state.gd.uid
+++ b/scripts/game_state.gd.uid
@@ -1,0 +1,1 @@
+uid://bndwnnyg3hghw

--- a/scripts/power_up/power_up.gd
+++ b/scripts/power_up/power_up.gd
@@ -1,0 +1,37 @@
+extends Node
+class_name PowerUp
+
+
+# Non-virtual interface pattern: 
+# this pattern adds a layer of indirection to virtual methods such that we can carry out pre and
+# post operations relative to the abstract operation we are carrying out (playing a sound every time
+# a power-up is used, for example)
+func apply_effect() -> void:
+	_apply_effect()
+	
+
+func is_applicable() -> bool:
+	return _is_applicable()
+
+
+func _apply_effect() -> void:
+	var caller_class_name := "unknown"
+	var script = get_script()
+	if script:
+		if script.has_method("get_global_name") and not script.get_global_name().is_empty():
+			caller_class_name = script.get_global_name()
+		else:
+			caller_class_name = script.resource_path.get_file().get_basename()
+	push_error("virtual method _apply_effect() not implemented in ", caller_class_name)
+
+
+func _is_applicable() -> bool:
+	var caller_class_name := "unknown"
+	var script = get_script()
+	if script:
+		if script.has_method("get_global_name") and not script.get_global_name().is_empty():
+			caller_class_name = script.get_global_name()
+		else:
+			caller_class_name = script.resource_path.get_file().get_basename()
+	push_error("virtual method _try_applying_effect() not implemented in ", caller_class_name)
+	return false

--- a/scripts/power_up/power_up.gd.uid
+++ b/scripts/power_up/power_up.gd.uid
@@ -1,0 +1,1 @@
+uid://bkak86ahi00mm


### PR DESCRIPTION
This PR aims to implement the base power-up class to be used by all power-ups in our game, it contains two virtual methods:

- One to check for application conditions, which returns a `bool` indicating if the effect meets application criteria or not.
- One to apply the power-up's effect.

Besides that, a new autoload scene `game_state.tscn` was added as a way for the power-ups to easily fetch the current game state and check for effect application conditions and apply them.

Closes #10.