### PR TITLE
Add Signal Bus to the project

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,7 @@ run/handheld/orientation=0
 [autoload]
 
 GameState="*uid://dalnv4ctvosjo"
+SignalBus="*uid://c8whqqleu2jbv"
 
 [display]
 

--- a/util/signal_bus/signal_bus.gd
+++ b/util/signal_bus/signal_bus.gd
@@ -1,0 +1,55 @@
+extends Node
+## Controls the flow of signals between [SignalBusSender] and[br]
+## [SignalBusReceiver].
+##
+## [u][color=yellow]It must be put as an Autoload[/color][/u]
+##
+## Example of workflow with [SignalBus]:
+## In a scene from where you want to send a [Signal], add a [SignalBusSender] node, and through[br]
+## the editor, connect the signal you want to send to [method SignalBusSender.connect_signal]. Then,[br]
+## you can call [method Signal.emit] as normal in the code.
+## In a scene you want to receive a [Signal], add a [SignalBusReceiver] node, and through[br]
+## the editor, connect the signal you want to receive from [SignalBusReceiver] to the function
+## you want to call.
+
+
+var _free_locks: Array[int] = []
+var _locks: Array[int] = []
+var _buffer: Array[Dictionary] = []
+
+
+func send(signal_name: StringName, args: Array):
+	print("sending ", signal_name)
+	if _locks.size() > 0:
+		_buffer.append({signal_name = signal_name, args = args})
+	else:
+		_broadcast(signal_name, args)
+
+
+func is_locked() -> bool:
+	return not _locks.is_empty()
+
+
+func lock() -> int:
+	var lock_id := -1
+	if _free_locks.is_empty():
+		lock_id = _locks.size() + 1
+	else:
+		lock_id = _free_locks.pop_front()
+	_locks.append(lock_id)
+	return lock_id
+
+
+func unlock(lock_id: int):
+	if lock_id in _locks:
+		_locks.erase(lock_id)
+		_free_locks.append(lock_id)
+	while not _buffer.is_empty() and _locks.is_empty():
+		var signal_call: Dictionary = _buffer.pop_front()
+		_broadcast(signal_call.signal_name, signal_call.args)
+
+
+func _broadcast(signal_name: StringName, args: Array):
+	print("broadcasting signal to the following receivers: ", SignalBusReceiver.all(get_tree()))
+	for receiver in SignalBusReceiver.all(get_tree()):
+		receiver.callv(&'emit_signal', [signal_name] + args)

--- a/util/signal_bus/signal_bus.gd.uid
+++ b/util/signal_bus/signal_bus.gd.uid
@@ -1,0 +1,1 @@
+uid://c8whqqleu2jbv

--- a/util/signal_bus/signal_bus_receiver.gd
+++ b/util/signal_bus/signal_bus_receiver.gd
@@ -1,0 +1,30 @@
+class_name SignalBusReceiver
+extends Node
+
+signal keyboard_enter_pressed()
+signal keyboard_delete_pressed()
+signal keyboard_KeyPress()
+
+const GROUP := &'RECEIVER_GROUP'
+
+static var _s_dirty := true
+static var _s_receivers: Array[SignalBusReceiver] = []
+
+
+func _enter_tree():
+	add_to_group(GROUP)
+	_s_dirty = true
+
+
+func _exit_tree():
+	_s_dirty = true
+
+
+static func all(tree: SceneTree) -> Array[SignalBusReceiver]:
+	if _s_dirty:
+		_s_receivers.clear()
+		for receiver: SignalBusReceiver in tree.get_nodes_in_group(GROUP):
+			if receiver:
+				_s_receivers.append(receiver)
+		_s_dirty = false
+	return _s_receivers

--- a/util/signal_bus/signal_bus_receiver.gd.uid
+++ b/util/signal_bus/signal_bus_receiver.gd.uid
@@ -1,0 +1,1 @@
+uid://b53cdeb3oi0lp

--- a/util/signal_bus/signal_bus_receiver.tscn
+++ b/util/signal_bus/signal_bus_receiver.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3 uid="uid://b4665yy0lwvt5"]
+
+[ext_resource type="Script" uid="uid://b53cdeb3oi0lp" path="res://util/signal_bus/signal_bus_receiver.gd" id="1_cop7h"]
+
+[node name="SignalBusReceiver" type="Node" unique_id=1996817024]
+script = ExtResource("1_cop7h")

--- a/util/signal_bus/signal_bus_sender.gd
+++ b/util/signal_bus/signal_bus_sender.gd
@@ -1,0 +1,33 @@
+class_name SignalBusSender
+extends Node
+
+@export var signal_prefix := ""
+
+func _ready() -> void:
+	_make_connections.call_deferred()
+
+## This function only acts as a way to store which signals are connected to this node
+func connect_signal(..._args):
+	return
+
+## Bind a custom signal name when connecting the signal
+func connect_signal_named(..._args):
+	return
+
+
+func _make_connections():
+	for conn_info in get_incoming_connections():
+		var sig: Signal = conn_info.signal
+		var clb: Callable = conn_info.callable
+		var sig_name: StringName = signal_prefix
+		
+		if clb.get_method() == connect_signal_named.get_method():
+			sig_name += clb.get_bound_arguments()[0]
+			clb.unbind(1)
+		else:
+			sig_name += sig.get_name()
+		
+		sig.connect(func(...args):
+			SignalBus.send(sig_name, args)
+		)
+		print("signal ", sig_name, " connected!")

--- a/util/signal_bus/signal_bus_sender.gd.uid
+++ b/util/signal_bus/signal_bus_sender.gd.uid
@@ -1,0 +1,1 @@
+uid://ctmgxked31vkh

--- a/util/signal_bus/signal_bus_sender.tscn
+++ b/util/signal_bus/signal_bus_sender.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3 uid="uid://bqy1v2k8j2a25"]
+
+[ext_resource type="Script" uid="uid://ctmgxked31vkh" path="res://util/signal_bus/signal_bus_sender.gd" id="1_8s2x5"]
+
+[node name="SignalBusSender" type="Node" unique_id=1721126377]
+script = ExtResource("1_8s2x5")


### PR DESCRIPTION
Signal Bus is a way to use an Autoload to broadcast signals through the node tree. It solves the problem of needing a reference to the node to which we want to connect a signal.

For this first iteration, it works with signals that can be connected _through the editor_ to the `SignalBusSender` node. For the specific example of `keyboard.gd`, where it has to connect signals through code, a workaround was done where connections in `SignalBusSender` were checked in a function called with `call_deferred()`. I'll still have to figure out how to deal with this problem.