### PR TITLE
Add random grid generation

### DIFF
--- a/assets/icon.svg.import
+++ b/assets/icon.svg.import
@@ -3,15 +3,11 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://bqlci3hunnwng"
-path="res://.godot/imported/icon.svg-56083ea2a1f1a4f1e49773bdc6d7826c.ctex"
-metadata={
-"vram_texture": false
-}
+valid=false
 
 [deps]
 
 source_file="res://assets/icon.svg"
-dest_files=["res://.godot/imported/icon.svg-56083ea2a1f1a4f1e49773bdc6d7826c.ctex"]
 
 [params]
 

--- a/game/level/grid.gd
+++ b/game/level/grid.gd
@@ -40,7 +40,11 @@ func get_cell_by_coordinates(row : int, col : int) -> LetterBox:
 func get_cell_by_index(i: int) -> LetterBox:
 	if i >= resource.cell_layout.size():
 		return null
-	var cell_position = resource.cell_layout.keys()[i]
+	# HACK this is a problem about doing things with dictionaries.
+	# Anything that needs to consider order will break sooner or later
+	var sorted_keys = resource.cell_layout.keys()
+	sorted_keys.sort()
+	var cell_position = sorted_keys[i]
 	return get_cell_by_coordinates(cell_position.x, cell_position.y)
 
 
@@ -49,6 +53,7 @@ func get_row(row: int) -> Dictionary[Vector2i, LetterBox]:
 	var coordinates_in_row = cell_layout.keys().filter(func(x):
 		return x.x == row and cell_layout[x].status != LetterBox.Status.DISABLED
 	)
+	print("these are the coordinates in this row: ", coordinates_in_row)
 	var cells_in_row: Dictionary[Vector2i, LetterBox] = {}
 	for coord in coordinates_in_row:
 		cells_in_row[coord] =  cell_layout[coord]
@@ -93,6 +98,8 @@ func setup(grid_resource: GridResource) -> void:
 
 
 func _setup_cells() -> void:
+	print("this grid resource has a grid of size: (", resource.grid_size.x, ", ", resource.grid_size.y, ")")
+	print("resource cell layout: ", resource.cell_layout)
 	for row in resource.grid_size.x:
 		for col in resource.grid_size.y:
 			var letter_box: LetterBox
@@ -102,3 +109,4 @@ func _setup_cells() -> void:
 				letter_box = LetterBox.create(" ", LetterBox.Status.DISABLED)
 			set_cell(row, col, letter_box)
 			cell_layout[Vector2i(row, col)] = letter_box
+	print("resulting cell layout: ", cell_layout)

--- a/game/level/grid.gd
+++ b/game/level/grid.gd
@@ -7,6 +7,8 @@ class_name Grid
 
 const WORD_GRID_SCENE_PATH = "res://game/level/grid.tscn"
 
+var cell_layout: Dictionary[Vector2i, LetterBox] # position of cell in grid / instance of cell
+
 @export var resource: GridResource = null
 @export_category("Nodes")
 @export var grid_container: GridContainer
@@ -20,6 +22,10 @@ func _ready() -> void:
 
 func _get_index(row : int, col : int) -> int:
 	return resource.grid_size.y*row + col
+
+
+func _get_coordinates(index: int) -> Vector2i:
+	return Vector2i(index / resource.grid_size.y, index % resource.grid_size.y)
 #endregion
 
 #region Public functions
@@ -38,6 +44,17 @@ func get_cell_by_index(i: int) -> LetterBox:
 	return get_cell_by_coordinates(cell_position.x, cell_position.y)
 
 
+## Get all the [LetterBox] in a single row
+func get_row(row: int) -> Dictionary[Vector2i, LetterBox]:
+	var coordinates_in_row = cell_layout.keys().filter(func(x):
+		return x.x == row and cell_layout[x].status != LetterBox.Status.DISABLED
+	)
+	var cells_in_row: Dictionary[Vector2i, LetterBox] = {}
+	for coord in coordinates_in_row:
+		cells_in_row[coord] =  cell_layout[coord]
+	return cells_in_row
+
+
 ## Set the cell at given coordinates
 ##
 ## [param row, col]: ith-row, jth-column
@@ -45,8 +62,8 @@ func set_cell(row : int, col : int, letter_box : LetterBox = null) -> void:
 	if letter_box == null:
 		letter_box = LetterBox.create(" ", LetterBox.Status.EMPTY)
 	var index = _get_index(row, col)
-	var old_node = grid_container.get_child(index)
-	if old_node != null:
+	if index < grid_container.get_child_count():
+		var old_node = grid_container.get_child(index)
 		old_node.queue_free()
 	grid_container.add_child(letter_box)
 	grid_container.move_child(letter_box, index)
@@ -84,3 +101,4 @@ func _setup_cells() -> void:
 			else:
 				letter_box = LetterBox.create(" ", LetterBox.Status.DISABLED)
 			set_cell(row, col, letter_box)
+			cell_layout[Vector2i(row, col)] = letter_box

--- a/game/level/grid.tscn
+++ b/game/level/grid.tscn
@@ -1,7 +1,6 @@
 [gd_scene format=3 uid="uid://c0hsy6u3o3kiq"]
 
 [ext_resource type="Script" uid="uid://dgercpqu4jq06" path="res://game/level/grid.gd" id="1_nl6dr"]
-[ext_resource type="Resource" uid="uid://b5108vevvolpb" path="res://resources/grid/test_grid.tres" id="2_apj8q"]
 
 [node name="Grid" type="Control" unique_id=688690635 node_paths=PackedStringArray("grid_container")]
 layout_mode = 3
@@ -19,7 +18,6 @@ grow_vertical = 2
 size_flags_horizontal = 4
 size_flags_vertical = 0
 script = ExtResource("1_nl6dr")
-resource = ExtResource("2_apj8q")
 grid_container = NodePath("GridContainer")
 
 [node name="GridContainer" type="GridContainer" parent="." unique_id=2041539914]

--- a/game/level/keyboard.gd
+++ b/game/level/keyboard.gd
@@ -35,15 +35,27 @@ func _ready() -> void:
 			_keys.append(key)
 			key.key_pressed.connect(_on_char_pressed)
 
+
+# Updates letter color based on secret word correctness
+func update_letter(letter: String, correctness: LetterBox.Correctness):
+	print("letter ", letter, " is ", correctness)
+	var key = get_key(letter)
+	var button: Button = key.find_child("Button")
+	button.modulate = correctness
+
+
 func _on_enter_button_up() -> void:
 	enter_pressed.emit()
+
 
 func _on_del_button_up() -> void:
 	delete_pressed.emit()
 
+
 func _on_char_pressed(c : String) -> void:
 	character_pressed.emit(c)
 	
+
 func _unhandled_input(event: InputEvent) -> void:
 	if event is InputEventKey and event.pressed:
 		var key_name = OS.get_keycode_string(event.keycode)

--- a/game/level/letter_box.gd
+++ b/game/level/letter_box.gd
@@ -7,19 +7,26 @@ const LETTERBOX_SCENE_PATH = "res://game/level/letter_box.tscn"
 enum Status{
 	EMPTY,
 	FULL,
+	DISABLED,
+}
+
+enum Correctness {
+	NONE,
 	WRONG,
 	MISPLACED,
 	CORRECT,
-	DISABLED,
 }
 
 const STATUS_COLORS = {
 	Status.EMPTY: Color(0.862, 0.849, 0.846),
 	Status.FULL: Color(0.862, 0.849, 0.846),
-	Status.WRONG: Color(0.325, 0.325, 0.325),
-	Status.MISPLACED: Color(1, 0.8, 0.2),
-	Status.CORRECT: Color(0.384, 0.873, 0.0),
 	Status.DISABLED: Color(0.094, 0.094, 0.094, 0.0)
+}
+
+const CORRECTNESS_COLORS = {
+	Correctness.WRONG: Color(0.325, 0.325, 0.325),
+	Correctness.MISPLACED: Color(1, 0.8, 0.2),
+	Correctness.CORRECT: Color(0.384, 0.873, 0.0),
 }
 
 @export var state_machine: CellStateMachine
@@ -28,7 +35,10 @@ var status : Status = Status.EMPTY:
 	set(status_v):
 		status = status_v
 		$TextureRect.modulate = STATUS_COLORS[status]
-
+var correctness: Correctness = Correctness.NONE:
+	set(value):
+		correctness = value
+		$TextureRect.modulate = CORRECTNESS_COLORS[correctness]
 var letter : String = "~":
 	set(letter_v):
 		letter = letter_v.to_upper()

--- a/game/level/level.gd
+++ b/game/level/level.gd
@@ -39,14 +39,18 @@ func char_pressed_callback(c : String) -> void:
 
 func enter_pressed_callback() -> void:
 	var letters_mystery_word = $GameState.mystery_word.split("")
+	# verifies if it takes the whole row
 	if (len($GameState.current_string_guess) >= $Grid.grid_size[1]):
+		# verifies if it is in dictionary
 		if ($GameState.current_string_guess not in words_list):
 			print("word doesn't exist !")
 			return
 		var number_correct : int = 0
+		# iterate through each letter
 		for j in range(len($GameState.current_string_guess)):
 			var letter_box : LetterBox = $Grid.get_cell($GameState.current_attempt, j)
 			var points_earned : int = 0
+			# verifies if it is in the right position
 			if ($GameState.current_string_guess[j] == $GameState.mystery_word[j]):
 				letters_mystery_word.erase($GameState.current_string_guess[j])
 				letter_box.status = LetterBox.Status.CORRECT
@@ -55,6 +59,7 @@ func enter_pressed_callback() -> void:
 				texture_rect.modulate = Color(0.0, 0.698, 0.0, 1.0)
 				number_correct+=1
 				points_earned = 10
+			# verifies if it is in the word
 			elif ($GameState.current_string_guess[j] in letters_mystery_word):
 				letters_mystery_word.erase($GameState.current_string_guess[j])
 				letter_box.status = LetterBox.Status.MISPLACED
@@ -62,6 +67,7 @@ func enter_pressed_callback() -> void:
 				var texture_rect : Button = key.find_child("Button")
 				texture_rect.modulate = Color(0.0, 0.698, 0.0, 1.0)
 				points_earned = 5
+			# not in word
 			else :
 				letter_box.status = LetterBox.Status.WRONG
 				var key : KeyboardKey = $Keyboard.get_key($GameState.current_string_guess[j])
@@ -71,6 +77,7 @@ func enter_pressed_callback() -> void:
 			letter_box.animate(points_earned)
 			$GameState.points += points_earned
 			await get_tree().create_timer(0.3).timeout
+		# checks if won
 		if (number_correct == $Grid.grid_size.y):
 			on_winning_do()
 			return

--- a/game/level/level_generator.gd
+++ b/game/level/level_generator.gd
@@ -6,6 +6,10 @@ class_name LevelGenerator
 @export var grid_scene: PackedScene
 @export var keyboard_scene: PackedScene
 @export var background_scene: PackedScene
+@export_group("Grid generation parameters")
+@export var min_word_size: int
+@export var max_word_size: int
+@export var attempts: int
 
 
 ## This function builds a [Level] from [Grid], [Keyboard], and [Background] resources.
@@ -16,6 +20,8 @@ func generate_level(grid_resource: GridResource, keyboard_resource: Resource, ba
 	var keyboard_node = keyboard_scene.instantiate()
 	var background_node = background_scene.instantiate()
 
+	if not grid_resource: 
+		grid_resource = GridEditor.generate_random_grid(min_word_size, max_word_size, attempts)
 	grid_node.setup(grid_resource)
 	#keyboard_node.setup(keyboard_resource)
 	#background_node.setup(background_resource)

--- a/game/level/level_manager.gd
+++ b/game/level/level_manager.gd
@@ -26,8 +26,12 @@ func choose_secret_word() -> void:
 	if not grid:
 		push_error("there is no grid for generating secret word!")
 	var last_row: int = -1
+	print("grid cell layout: ", grid.cell_layout)
 	for coord in grid.cell_layout.keys():
+		print("last row: ", last_row)
+		print("coord: ", coord, ", and coord.x: ", coord.x)
 		last_row = max(last_row, coord.x)
+	print("last row is row ", last_row)
 	var last_row_cells = grid.get_row(last_row)
 	print("cells in last row are: ", last_row_cells)
 	secret_word_string = GameDictionary.pick_random_word_of_size(last_row_cells.size())

--- a/game/level/level_manager.gd
+++ b/game/level/level_manager.gd
@@ -37,7 +37,7 @@ func _is_last_cell_in_row() -> bool:
 
 
 func _is_valid_guess() -> bool:
-	return true
+	return _is_last_cell_in_row() and GameDictionary.is_in_dictionary(current_guess)
 	
 
 func _on_keyboard_character_pressed(c: String) -> void:

--- a/game/level/level_manager.gd
+++ b/game/level/level_manager.gd
@@ -18,7 +18,7 @@ var current_guess: String = ""
 var correct_letters_in_guess: int = 0
 var grid: Grid
 var keyboard: Keyboard
-var secret_word: Dictionary[String, int] # (character, column)
+var secret_word: Dictionary[String, Array] # (character, list of column indices this character occurs)
 
 
 func choose_secret_word() -> void: 
@@ -31,7 +31,7 @@ func choose_secret_word() -> void:
 	print("cells in last row are: ", last_row_cells)
 	var secret_word_string := GameDictionary.pick_random_word_of_size(last_row_cells.size())
 	for i in secret_word_string.length():
-		secret_word[secret_word_string[i]] = last_row_cells.keys()[i].y
+		secret_word.get_or_add(secret_word_string[i], []).append(last_row_cells.keys()[i].y)
 	print("secret word is: ", secret_word_string)
 	print(secret_word)
 	
@@ -45,14 +45,14 @@ func resolve_guess() -> void:
 	for coord in row_letters:
 		_resolve_letter_guess(coord, row_letters[coord])
 		_resolve_letter_effect(coord, row_letters[coord])
-	if correct_letters_in_guess == secret_word.keys().size():
+	if correct_letters_in_guess == current_guess.length():
 		_win()
 	correct_letters_in_guess = 0
 
 
 func _resolve_letter_guess(coordinates: Vector2i, letter: LetterBox):
 	if letter.letter in secret_word.keys():
-		if coordinates.y == secret_word[letter.letter]:
+		if coordinates.y in secret_word[letter.letter]:
 			letter.correctness = LetterBox.Correctness.CORRECT
 			correct_letters_in_guess += 1
 		else:

--- a/game/level/level_manager.gd
+++ b/game/level/level_manager.gd
@@ -9,19 +9,62 @@ class_name LevelManager
 # - it keeps track of how many points the player has
 # - it keeps track of the "challenges" the player has to complete to gain coins (coin power-ups)
 # - it keeps track of word resolution (ordering of effect resolution function calls, total number of points scored, etc.)
-# TODO create files for each word size, or organize words.txt into a JSON with word sizes 
-const WORDS_PATH : String = "res://words.txt"
 
 @export var receiver: SignalBusReceiver
 
 var next_cell_to_fill_idx: int = 0
 var current_row: int = 0
 var current_guess: String = ""
+var correct_letters_in_guess: int = 0
 var grid: Grid
+var keyboard: Keyboard
+var secret_word: Dictionary[String, int] # (character, column)
 
+
+func choose_secret_word() -> void: 
+	if not grid:
+		push_error("there is no grid for generating secret word!")
+	var last_row: int = -1
+	for coord in grid.cell_layout.keys():
+		last_row = max(last_row, coord.x)
+	var last_row_cells = grid.get_row(last_row)
+	print("cells in last row are: ", last_row_cells)
+	var secret_word_string := GameDictionary.pick_random_word_of_size(last_row_cells.size())
+	for i in secret_word_string.length():
+		secret_word[secret_word_string[i]] = last_row_cells.keys()[i].y
+	print("secret word is: ", secret_word_string)
+	print(secret_word)
+	
 
 func get_next_cell_to_fill() -> void:
 	return grid.get_cell_by_index(next_cell_to_fill_idx)
+
+
+func resolve_guess() -> void:
+	var row_letters := grid.get_row(current_row)
+	for coord in row_letters:
+		_resolve_letter_guess(coord, row_letters[coord])
+		_resolve_letter_effect(coord, row_letters[coord])
+	if correct_letters_in_guess == secret_word.keys().size():
+		_win()
+	correct_letters_in_guess = 0
+
+
+func _resolve_letter_guess(coordinates: Vector2i, letter: LetterBox):
+	if letter.letter in secret_word.keys():
+		if coordinates.y == secret_word[letter.letter]:
+			letter.correctness = LetterBox.Correctness.CORRECT
+			correct_letters_in_guess += 1
+		else:
+			letter.correctness = LetterBox.Correctness.MISPLACED
+	else:
+		letter.correctness = LetterBox.Correctness.WRONG
+	keyboard.update_letter(letter.letter, letter.correctness)
+
+
+func _resolve_letter_effect(coordinates: Vector2i, letter: LetterBox):
+	# call here the "apply_effect()" or equivalent in the PowerUp stored in the LetterBox instance.
+	pass
 
 
 func _get_next_row() -> int:
@@ -39,6 +82,10 @@ func _is_last_cell_in_row() -> bool:
 func _is_valid_guess() -> bool:
 	return _is_last_cell_in_row() and GameDictionary.is_in_dictionary(current_guess)
 	
+
+func _win() -> void:
+	print("you won... now what?")
+
 
 func _on_keyboard_character_pressed(c: String) -> void:
 	if _is_last_cell_in_row():
@@ -66,5 +113,6 @@ func _on_keyboard_enter_pressed() -> void:
 		print("not a valid guess")
 		return
 	# TODO resolve guess, effects, and earn points
+	resolve_guess()
 	current_row = _get_next_row()
 	current_guess = ""

--- a/game/level/level_manager.gd
+++ b/game/level/level_manager.gd
@@ -19,6 +19,7 @@ var correct_letters_in_guess: int = 0
 var grid: Grid
 var keyboard: Keyboard
 var secret_word: Dictionary[String, Array] # (character, list of column indices this character occurs)
+var secret_word_string: String
 
 
 func choose_secret_word() -> void: 
@@ -29,7 +30,7 @@ func choose_secret_word() -> void:
 		last_row = max(last_row, coord.x)
 	var last_row_cells = grid.get_row(last_row)
 	print("cells in last row are: ", last_row_cells)
-	var secret_word_string := GameDictionary.pick_random_word_of_size(last_row_cells.size())
+	secret_word_string = GameDictionary.pick_random_word_of_size(last_row_cells.size())
 	for i in secret_word_string.length():
 		secret_word.get_or_add(secret_word_string[i], []).append(last_row_cells.keys()[i].y)
 	print("secret word is: ", secret_word_string)
@@ -40,26 +41,40 @@ func get_next_cell_to_fill() -> void:
 	return grid.get_cell_by_index(next_cell_to_fill_idx)
 
 
+# TODO think of a better way of dealing with the points, like having a "base_points"
+# based on letter judgement, then resolve the effects as a list of functions that take
+# those "base_points" and return the modified value to chain with the next effect or something like that.
 func resolve_guess() -> void:
+	var points: int = 0
 	var row_letters := grid.get_row(current_row)
 	for coord in row_letters:
-		_resolve_letter_guess(coord, row_letters[coord])
+		points += _resolve_letter_guess(coord, row_letters[coord])
 		_resolve_letter_effect(coord, row_letters[coord])
-	if correct_letters_in_guess == current_guess.length():
+		row_letters[coord].animate(points)
+		# TODO I feel this should be inside the animation script
+		await get_tree().create_timer(0.3).timeout
+	if correct_letters_in_guess == current_guess.length() \
+		and current_guess.length() == secret_word_string.length():
 		_win()
 	correct_letters_in_guess = 0
+	current_guess = ""
 
 
 func _resolve_letter_guess(coordinates: Vector2i, letter: LetterBox):
+	var points := 0
 	if letter.letter in secret_word.keys():
 		if coordinates.y in secret_word[letter.letter]:
 			letter.correctness = LetterBox.Correctness.CORRECT
 			correct_letters_in_guess += 1
+			points += 10
 		else:
 			letter.correctness = LetterBox.Correctness.MISPLACED
+			points += 5
 	else:
 		letter.correctness = LetterBox.Correctness.WRONG
+		points += 1
 	keyboard.update_letter(letter.letter, letter.correctness)
+	return points
 
 
 func _resolve_letter_effect(coordinates: Vector2i, letter: LetterBox):
@@ -115,4 +130,3 @@ func _on_keyboard_enter_pressed() -> void:
 	# TODO resolve guess, effects, and earn points
 	resolve_guess()
 	current_row = _get_next_row()
-	current_guess = ""

--- a/game/level/level_template.gd
+++ b/game/level/level_template.gd
@@ -5,6 +5,7 @@ class_name LevelTemplate
 # This script's sole purpose is to organize the elements visually on the screen for the level. That means:
 # - taking a grid, a keyboard, and a background node, and organizing the UI visually
 # - making all signal connections needed for the interaction to work
+# - initiating all the components of the level accordingly
 # What this script DOES NOT do:
 # - keep updating the UI (the ones who _should_ do this are specialized scripts, such as [for example] PointsLabel, LetterBox, Grid...)
 
@@ -38,3 +39,6 @@ func setup() -> void:
 	keyboard.position = Vector2(325, 971)
 
 	level_manager.grid = grid
+	level_manager.keyboard = keyboard
+
+	level_manager.choose_secret_word()

--- a/game/level/manager/level_manager_test.tscn
+++ b/game/level/manager/level_manager_test.tscn
@@ -1,7 +1,6 @@
 [gd_scene format=3 uid="uid://c362h4uhvx6sm"]
 
 [ext_resource type="Script" uid="uid://j18mtq2kkfnj" path="res://game/level/manager/level_manager_test.gd" id="1_1y6ow"]
-[ext_resource type="Resource" uid="uid://b7nldiw63auaw" path="res://resources/grid/test_grid.tres" id="2_hovls"]
 [ext_resource type="PackedScene" uid="uid://cbfgjolpavjft" path="res://game/level/level_generator.tscn" id="3_ntai4"]
 [ext_resource type="PackedScene" uid="uid://c0hsy6u3o3kiq" path="res://game/level/grid.tscn" id="4_y2dic"]
 [ext_resource type="PackedScene" uid="uid://bgqr6a5l1ohly" path="res://game/level/keyboard.tscn" id="5_f4oy5"]
@@ -9,10 +8,12 @@
 
 [node name="LevelManagerTest" type="Node2D" unique_id=327929795 node_paths=PackedStringArray("generator")]
 script = ExtResource("1_1y6ow")
-grid = ExtResource("2_hovls")
 generator = NodePath("LevelGenerator")
 
 [node name="LevelGenerator" parent="." unique_id=2132408830 instance=ExtResource("3_ntai4")]
 grid_scene = ExtResource("4_y2dic")
 keyboard_scene = ExtResource("5_f4oy5")
 background_scene = ExtResource("6_fcflg")
+min_word_size = 3
+max_word_size = 5
+attempts = 9

--- a/project.godot
+++ b/project.godot
@@ -25,6 +25,7 @@ buses/default_bus_layout=""
 
 GameState="*uid://dalnv4ctvosjo"
 SignalBus="*uid://c8whqqleu2jbv"
+GameDictionary="*uid://boljwodxieax"
 
 [display]
 

--- a/resources/grid/grid_3597224707.tres
+++ b/resources/grid/grid_3597224707.tres
@@ -1,0 +1,23 @@
+[gd_resource type="Resource" script_class="GridResource" format=3]
+
+[ext_resource type="Script" path="res://resources/grid/grid_resource.gd" id="1_1bv5n"]
+
+[resource]
+script = ExtResource("1_1bv5n")
+grid_size = Vector2i(5, 4)
+cell_layout = Dictionary[Vector2i, int]({
+Vector2i(0, 0): 0,
+Vector2i(0, 1): 0,
+Vector2i(0, 2): 0,
+Vector2i(1, 1): 0,
+Vector2i(1, 2): 0,
+Vector2i(1, 3): 0,
+Vector2i(2, 1): 0,
+Vector2i(2, 2): 0,
+Vector2i(2, 3): 0,
+Vector2i(3, 0): 0,
+Vector2i(3, 1): 0,
+Vector2i(3, 2): 0,
+Vector2i(4, 0): 0
+})
+metadata/_custom_type_script = "uid://dj5l3hhcq02ng"

--- a/resources/grid/grid_smile.tres
+++ b/resources/grid/grid_smile.tres
@@ -1,0 +1,38 @@
+[gd_resource type="Resource" script_class="GridResource" format=3 uid="uid://bs6dliv8yxtcd"]
+
+[ext_resource type="Script" uid="uid://dj5l3hhcq02ng" path="res://resources/grid/grid_resource.gd" id="1_4ih3b"]
+
+[resource]
+script = ExtResource("1_4ih3b")
+grid_size = Vector2i(9, 10)
+cell_layout = Dictionary[Vector2i, int]({
+Vector2i(0, 0): 0,
+Vector2i(0, 1): 0,
+Vector2i(0, 2): 0,
+Vector2i(0, 7): 0,
+Vector2i(0, 8): 0,
+Vector2i(0, 9): 0,
+Vector2i(1, 3): 0,
+Vector2i(1, 6): 0,
+Vector2i(3, 2): 0,
+Vector2i(3, 3): 0,
+Vector2i(3, 6): 0,
+Vector2i(3, 7): 0,
+Vector2i(4, 2): 0,
+Vector2i(4, 3): 0,
+Vector2i(4, 6): 0,
+Vector2i(4, 7): 0,
+Vector2i(6, 1): 0,
+Vector2i(6, 2): 0,
+Vector2i(6, 7): 0,
+Vector2i(6, 8): 0,
+Vector2i(7, 2): 0,
+Vector2i(7, 3): 0,
+Vector2i(7, 4): 0,
+Vector2i(7, 5): 0,
+Vector2i(7, 6): 0,
+Vector2i(7, 7): 0,
+Vector2i(8, 4): 0,
+Vector2i(8, 5): 0
+})
+metadata/_custom_type_script = "uid://dj5l3hhcq02ng"

--- a/resources/grid/test_grid.tres
+++ b/resources/grid/test_grid.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="GridResource" format=3 uid="uid://b7nldiw63auaw"]
+[gd_resource type="Resource" script_class="GridResource" format=3 uid="uid://bnoa1uw1djshh"]
 
 [ext_resource type="Script" uid="uid://dj5l3hhcq02ng" path="res://resources/grid/grid_resource.gd" id="1_ucrdm"]
 
@@ -18,8 +18,11 @@ Vector2i(3, 2): 0,
 Vector2i(3, 3): 0,
 Vector2i(3, 4): 0,
 Vector2i(3, 5): 0,
+Vector2i(4, 1): 0,
+Vector2i(4, 4): 0,
 Vector2i(5, 1): 0,
 Vector2i(5, 2): 0,
-Vector2i(5, 3): 0
+Vector2i(5, 3): 0,
+Vector2i(5, 4): 0
 })
 metadata/_custom_type_script = "uid://dj5l3hhcq02ng"

--- a/util/dictionary/game_dictionary.gd
+++ b/util/dictionary/game_dictionary.gd
@@ -1,0 +1,38 @@
+extends Node
+## Class for loading a dictionary into the game and consulting it. It provides an API for
+## consulting whether a word is or not in the dictionary, and also to randomly pick words.
+
+const DICTIONARY_FILE_PATH = "res://util/dictionary/english_dictionary.json"
+var words: Dictionary = {}
+
+
+func _ready() -> void:
+	_load_dictionary(DICTIONARY_FILE_PATH)
+
+
+func pick_random_word_of_size(size: int) -> String:
+	return words[str(size)].keys().pick_random()
+
+
+func is_in_dictionary(word: String) -> bool:
+	var word_size = word.length()
+	return words[str(word_size)].has(word)
+
+
+func get_definition(word: String) -> Array:
+	if not is_in_dictionary(word):
+		return []
+	var word_size = word.length()
+	return words[str(word_size)][word]["MEANINGS"]
+
+
+func _load_dictionary(path: String) -> void:
+	if not FileAccess.file_exists(path):
+		print("Dictionary file does not exist.")
+		return
+	var data_file = FileAccess.open(path, FileAccess.READ)
+	var parsed_result = JSON.parse_string(data_file.get_as_text())
+	if not parsed_result is Dictionary:
+		print("Error loading dictionary.")
+		return 
+	words = parsed_result

--- a/util/dictionary/game_dictionary.gd.uid
+++ b/util/dictionary/game_dictionary.gd.uid
@@ -1,0 +1,1 @@
+uid://boljwodxieax

--- a/util/grid_editor/grid_editor.gd
+++ b/util/grid_editor/grid_editor.gd
@@ -7,10 +7,12 @@ class_name GridEditor
 @export_range(1, 100) var grid_size_x: int = 5:
 	set(value):
 		grid_size_x = value
+		grid_resource.grid_size.x = value
 		_update_grid_container()
 @export_range(1, 100) var grid_size_y: int = 5:
 	set(value):
 		grid_size_y = value
+		grid_resource.grid_size.y = value
 		_update_grid_container()
 @export var grid_resource: GridResource = GridResource.new():
 	set(value):
@@ -33,13 +35,13 @@ func _ready() -> void:
 func _update_grid_container() -> void:
 	if grid_container == null:
 		return
-	grid_container.columns = grid_size_x
+	grid_container.columns = grid_size_y
 	var cells = grid_container.get_children()
 	for cell in cells:
 		cell.queue_free()
 	for i in range(grid_size_x * grid_size_y):
 		var cell_node = editor_cell_scene.instantiate()
-		cell_node.cell_position = Vector2i(i / grid_size_x, i % grid_size_x)
+		cell_node.cell_position = Vector2i(i / grid_size_y, i % grid_size_y)
 		if cell_layout.has(cell_node.cell_position):
 			cell_node.activated = true
 		grid_container.add_child(cell_node)
@@ -91,7 +93,29 @@ func _on_editor_cell_pressed(cell: EditorCell) -> void:
 
 func _on_save_pressed() -> void:
 	grid_resource.cell_layout = cell_layout
+	print("previous grid layout: ", cell_layout)
 	_save_normalized_grid()
+	print("new grid layout: ", grid_resource.cell_layout)
 	if not grid_resource.resource_path.ends_with(".tres"):
-		grid_resource.take_over_path(default_save_path + "grid_" + Time.get_datetime_string_from_system() + ".tres")
+		var time = Time.get_datetime_string_from_system()
+		grid_resource.take_over_path(default_save_path + "grid_" + time + ".tres")
+		grid_resource = load(default_save_path + "grid_" + time + ".tres")
 	ResourceSaver.save(grid_resource, grid_resource.resource_path)
+
+
+# NOTE: this random generator function only generates grids that bound the max_word_size, and
+# that have no blank space between attempts. To craft a crazier level, please use the editor.
+# Further improvement in this sense could be made for the random generator.
+static func generate_random_grid(min_word_size: int, max_word_size: int, attempts: int) -> GridResource:
+	var resource = GridResource.new()
+	var grid_size: Vector2i = Vector2i(attempts, max_word_size)
+	var cell_layout: Dictionary[Vector2i, int] = {}
+	for attempt in range(attempts):
+		var columns = range(max_word_size)
+		for i in range(randi_range(min_word_size, max_word_size)):
+			var column = columns.pick_random()
+			columns.erase(column)
+			cell_layout[Vector2i(attempt, column)] = 0		
+	resource.grid_size = grid_size
+	resource.cell_layout = cell_layout
+	return resource

--- a/util/grid_editor/grid_editor.tscn
+++ b/util/grid_editor/grid_editor.tscn
@@ -2,8 +2,13 @@
 
 [ext_resource type="Script" uid="uid://c658n4ghc7jtb" path="res://util/grid_editor/grid_editor.gd" id="1_rqv84"]
 [ext_resource type="PackedScene" uid="uid://23occinmjclh" path="res://util/grid_editor/editor_cell.tscn" id="2_cqe2q"]
-[ext_resource type="Resource" uid="uid://b7nldiw63auaw" path="res://resources/grid/test_grid.tres" id="2_wryuq"]
+[ext_resource type="Script" uid="uid://dj5l3hhcq02ng" path="res://resources/grid/grid_resource.gd" id="2_wryuq"]
 [ext_resource type="PackedScene" uid="uid://b4665yy0lwvt5" path="res://util/signal_bus/signal_bus_receiver.tscn" id="3_uq5i1"]
+
+[sub_resource type="Resource" id="Resource_cu7ls"]
+script = ExtResource("2_wryuq")
+grid_size = Vector2i(72, 62)
+metadata/_custom_type_script = "uid://dj5l3hhcq02ng"
 
 [node name="GridEditor" type="Control" unique_id=2062166691 node_paths=PackedStringArray("grid_container")]
 layout_mode = 3
@@ -13,9 +18,9 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_rqv84")
-grid_size_x = 6
-grid_size_y = 6
-grid_resource = ExtResource("2_wryuq")
+grid_size_x = 41
+grid_size_y = 56
+grid_resource = SubResource("Resource_cu7ls")
 grid_container = NodePath("VBoxContainer/ScrollContainer/GridContainer")
 editor_cell_scene = ExtResource("2_cqe2q")
 
@@ -38,7 +43,7 @@ size_flags_vertical = 3
 
 [node name="GridContainer" type="GridContainer" parent="VBoxContainer/ScrollContainer" unique_id=207068468]
 layout_mode = 2
-columns = 6
+columns = 41
 
 [node name="SignalBusReceiver" parent="." unique_id=1996817024 instance=ExtResource("3_uq5i1")]
 

--- a/util/grid_editor/grid_editor.tscn
+++ b/util/grid_editor/grid_editor.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://c658n4ghc7jtb" path="res://util/grid_editor/grid_editor.gd" id="1_rqv84"]
 [ext_resource type="PackedScene" uid="uid://23occinmjclh" path="res://util/grid_editor/editor_cell.tscn" id="2_cqe2q"]
-[ext_resource type="Resource" path="res://resources/grid/test_grid.tres" id="2_wryuq"]
+[ext_resource type="Resource" uid="uid://b7nldiw63auaw" path="res://resources/grid/test_grid.tres" id="2_wryuq"]
 [ext_resource type="PackedScene" uid="uid://b4665yy0lwvt5" path="res://util/signal_bus/signal_bus_receiver.tscn" id="3_uq5i1"]
 
 [node name="GridEditor" type="Control" unique_id=2062166691 node_paths=PackedStringArray("grid_container")]
@@ -13,8 +13,8 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_rqv84")
-grid_size_x = 4
-grid_size_y = 4
+grid_size_x = 6
+grid_size_y = 6
 grid_resource = ExtResource("2_wryuq")
 grid_container = NodePath("VBoxContainer/ScrollContainer/GridContainer")
 editor_cell_scene = ExtResource("2_cqe2q")
@@ -38,7 +38,7 @@ size_flags_vertical = 3
 
 [node name="GridContainer" type="GridContainer" parent="VBoxContainer/ScrollContainer" unique_id=207068468]
 layout_mode = 2
-columns = 4
+columns = 6
 
 [node name="SignalBusReceiver" parent="." unique_id=1996817024 instance=ExtResource("3_uq5i1")]
 

--- a/util/grid_editor/grid_editor.tscn
+++ b/util/grid_editor/grid_editor.tscn
@@ -2,13 +2,8 @@
 
 [ext_resource type="Script" uid="uid://c658n4ghc7jtb" path="res://util/grid_editor/grid_editor.gd" id="1_rqv84"]
 [ext_resource type="PackedScene" uid="uid://23occinmjclh" path="res://util/grid_editor/editor_cell.tscn" id="2_cqe2q"]
-[ext_resource type="Script" uid="uid://dj5l3hhcq02ng" path="res://resources/grid/grid_resource.gd" id="2_wryuq"]
+[ext_resource type="Resource" uid="uid://bs6dliv8yxtcd" path="res://resources/grid/grid_smile.tres" id="2_wryuq"]
 [ext_resource type="PackedScene" uid="uid://b4665yy0lwvt5" path="res://util/signal_bus/signal_bus_receiver.tscn" id="3_uq5i1"]
-
-[sub_resource type="Resource" id="Resource_cu7ls"]
-script = ExtResource("2_wryuq")
-grid_size = Vector2i(72, 62)
-metadata/_custom_type_script = "uid://dj5l3hhcq02ng"
 
 [node name="GridEditor" type="Control" unique_id=2062166691 node_paths=PackedStringArray("grid_container")]
 layout_mode = 3
@@ -18,9 +13,9 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_rqv84")
-grid_size_x = 41
-grid_size_y = 56
-grid_resource = SubResource("Resource_cu7ls")
+grid_size_x = 22
+grid_size_y = 18
+grid_resource = ExtResource("2_wryuq")
 grid_container = NodePath("VBoxContainer/ScrollContainer/GridContainer")
 editor_cell_scene = ExtResource("2_cqe2q")
 
@@ -43,7 +38,7 @@ size_flags_vertical = 3
 
 [node name="GridContainer" type="GridContainer" parent="VBoxContainer/ScrollContainer" unique_id=207068468]
 layout_mode = 2
-columns = 41
+columns = 22
 
 [node name="SignalBusReceiver" parent="." unique_id=1996817024 instance=ExtResource("3_uq5i1")]
 


### PR DESCRIPTION
Now, a static method at `GridEditor` generates a random grid given a min
and max sizes to guesses, as well as a number of attempts. It then
returns a `GridResource` that contains a random cell layout given these
parameters.

Note that grids made this way are not very elaborate, so we may still
want to create grids by hand for boss levels.