### PR TITLE
Grid multi touch gestures

### DIFF
--- a/game/level/grid.gd
+++ b/game/level/grid.gd
@@ -12,6 +12,7 @@ var cell_layout: Dictionary[Vector2i, LetterBox] # position of cell in grid / in
 @export var resource: GridResource = null
 @export_category("Nodes")
 @export var grid_container: GridContainer
+@export var grid_gestures: GridGestures
 #endregion
 
 #region Private functions

--- a/game/level/grid.tscn
+++ b/game/level/grid.tscn
@@ -1,24 +1,25 @@
 [gd_scene format=3 uid="uid://c0hsy6u3o3kiq"]
 
 [ext_resource type="Script" uid="uid://dgercpqu4jq06" path="res://game/level/grid.gd" id="1_nl6dr"]
+[ext_resource type="PackedScene" uid="uid://cxdg0yiumvkqb" path="res://util/gestures/touch_gestures.tscn" id="2_apj8q"]
+[ext_resource type="PackedScene" uid="uid://cpwbaa6s4byvc" path="res://util/gestures/grid_gestures.tscn" id="3_ta2np"]
+[ext_resource type="PackedScene" uid="uid://b4665yy0lwvt5" path="res://util/signal_bus/signal_bus_receiver.tscn" id="4_jfrtg"]
+[ext_resource type="Script" uid="uid://bpv8dvha8ck34" path="res://util/gestures/grid_gestures.gd" id="4_yl3un"]
 
-[node name="Grid" type="Control" unique_id=688690635 node_paths=PackedStringArray("grid_container")]
+[node name="Grid" type="Control" unique_id=688690635 node_paths=PackedStringArray("grid_container", "grid_gestures")]
 layout_mode = 3
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -165.5
-offset_top = -166.5
-offset_right = 165.5
-offset_bottom = 166.5
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 4
 size_flags_vertical = 0
 script = ExtResource("1_nl6dr")
 grid_container = NodePath("GridContainer")
+grid_gestures = NodePath("GridGestures")
 
 [node name="GridContainer" type="GridContainer" parent="." unique_id=2041539914]
 layout_mode = 1
@@ -29,6 +30,16 @@ anchor_right = 0.5
 anchor_bottom = 0.5
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/h_separation = 4
-theme_override_constants/v_separation = 4
+theme_override_constants/h_separation = 10
+theme_override_constants/v_separation = 10
 columns = 5
+
+[node name="TouchGestures" parent="." unique_id=1720384620 instance=ExtResource("2_apj8q")]
+
+[node name="GridGestures" parent="." unique_id=2122793614 instance=ExtResource("3_ta2np")]
+script = ExtResource("4_yl3un")
+
+[node name="SignalBusReceiver" parent="." unique_id=1996817024 instance=ExtResource("4_jfrtg")]
+
+[connection signal="touch_gestures_drag_detected" from="SignalBusReceiver" to="GridGestures" method="_on_touch_gestures_drag_detected"]
+[connection signal="touch_gestures_pinch_detected" from="SignalBusReceiver" to="GridGestures" method="_on_touch_gestures_pinch_detected"]

--- a/game/level/grid_blur.gdshader
+++ b/game/level/grid_blur.gdshader
@@ -1,0 +1,14 @@
+shader_type canvas_item;
+
+uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_linear_mipmap;
+uniform float max_blur_amount : hint_range(0.0, 5.0) = 2.5;
+uniform vec2 center = vec2(0.5, 0.5);
+uniform float vignette_radius : hint_range(0.0, 1.0) = 0.2; 
+uniform float vignette_softness : hint_range(0.0, 1.0) = 0.5; 
+
+void fragment() {
+    float dist = distance(UV, center);
+    float blur_factor = smoothstep(vignette_radius, vignette_radius + vignette_softness, dist);
+    float current_blur = blur_factor * max_blur_amount;
+    COLOR = textureLod(screen_texture, SCREEN_UV, current_blur);
+}

--- a/game/level/grid_blur.gdshader.uid
+++ b/game/level/grid_blur.gdshader.uid
@@ -1,0 +1,1 @@
+uid://bqbt5214hwxwf

--- a/game/level/level_template.gd
+++ b/game/level/level_template.gd
@@ -18,6 +18,8 @@ class_name LevelTemplate
 @export var background: ColorRect
 @export var level_manager: LevelManager
 @export var blackout: ColorRect
+@export var sub_viewport: SubViewport
+@export var sub_viewport_container: SubViewportContainer
 @export var point_threshold: int
 
 
@@ -27,12 +29,12 @@ var words_list : Array = []
 ## Sets up the current level's UI elements. It assumes [member LevelTemplate.grid], [member LevelTemplate.keyboard] and
 ## [member LevelTemplate.background] are set.
 func setup() -> void:
-	add_child(grid)
+	sub_viewport.add_child(grid)
 	add_child(keyboard)
 	add_child(background)
 
 	move_child(background, 0)
-	move_child(grid, -1)
+	#move_child(sub_viewport_container, -1)
 	move_child(keyboard, -1)
 	
 	blackout.size = Vector2(
@@ -41,8 +43,7 @@ func setup() -> void:
 	)
 	move_child(blackout, -1)
 	move_child(winning_menu, -1)
-	grid.size = Vector2(229, 200)
-	grid.position = Vector2(220, 278)
+	#grid.size = Vector2(229, 200)
 	keyboard.set_anchors_preset(Control.LayoutPreset.PRESET_CENTER)
 	keyboard.position = Vector2(325, 971)
 

--- a/game/level/level_template.gd
+++ b/game/level/level_template.gd
@@ -20,6 +20,7 @@ class_name LevelTemplate
 @export var blackout: ColorRect
 @export var sub_viewport: SubViewport
 @export var sub_viewport_container: SubViewportContainer
+@export var camera: Camera2D
 @export var point_threshold: int
 
 
@@ -36,7 +37,8 @@ func setup() -> void:
 	move_child(background, 0)
 	#move_child(sub_viewport_container, -1)
 	move_child(keyboard, -1)
-	
+
+	grid.grid_gestures.camera = camera
 	blackout.size = Vector2(
 		ProjectSettings.get_setting("display/window/size/viewport_width"), 
 		ProjectSettings.get_setting("display/window/size/viewport_height")

--- a/game/level/level_template.tscn
+++ b/game/level/level_template.tscn
@@ -1,17 +1,64 @@
 [gd_scene format=3 uid="uid://dd0ghiy6m86pg"]
 
 [ext_resource type="Script" uid="uid://df2gmrvkmddap" path="res://game/level/level_template.gd" id="1_pp25q"]
+[ext_resource type="PackedScene" uid="uid://c0hsy6u3o3kiq" path="res://game/level/grid.tscn" id="2_5u05p"]
+[ext_resource type="Shader" uid="uid://c05k3j03rqccv" path="res://game/level/sharp_grid.gdshader" id="4_igljq"]
 [ext_resource type="PackedScene" uid="uid://dvaakqo7jy3n1" path="res://game/level/level_manager.tscn" id="4_pp25q"]
 [ext_resource type="PackedScene" uid="uid://bmoauvxgxh2nr" path="res://game/level/winning_menu.tscn" id="5_hc0mr"]
 [ext_resource type="PackedScene" path="res://game/level/score.tscn" id="6_4ub6d"]
+[ext_resource type="Shader" uid="uid://bqbt5214hwxwf" path="res://game/level/grid_blur.gdshader" id="7_igljq"]
 
-[node name="LevelTemplate" type="Node2D" unique_id=1641894213 node_paths=PackedStringArray("winning_menu", "game_over_ui", "level_label", "level_manager", "blackout")]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_puvdw"]
+shader = ExtResource("7_igljq")
+shader_parameter/max_blur_amount = 4.9450002348875
+shader_parameter/center = Vector2(0.5, 0.5)
+shader_parameter/vignette_radius = 0.3210000152475
+shader_parameter/vignette_softness = 0.4910000233225
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_cq453"]
+shader = ExtResource("4_igljq")
+shader_parameter/center = Vector2(0.5, 0.5)
+shader_parameter/vignette_radius = 0.210000009975
+shader_parameter/vignette_softness = 0.350000016625
+
+[sub_resource type="ViewportTexture" id="ViewportTexture_puvdw"]
+viewport_path = NodePath("SubViewportContainer/SubViewport")
+
+[node name="LevelTemplate" type="Node2D" unique_id=1641894213 node_paths=PackedStringArray("winning_menu", "game_over_ui", "level_label", "level_manager", "blackout", "sub_viewport", "sub_viewport_container")]
 script = ExtResource("1_pp25q")
 winning_menu = NodePath("WinningMenu")
 game_over_ui = NodePath("GameOverUI")
 level_label = NodePath("LevelLabel")
 level_manager = NodePath("LevelManager")
 blackout = NodePath("Blackout")
+sub_viewport = NodePath("SubViewportContainer/SubViewport")
+sub_viewport_container = NodePath("SubViewportContainer")
+
+[node name="SubViewportContainer" type="SubViewportContainer" parent="." unique_id=1308685668]
+material = SubResource("ShaderMaterial_puvdw")
+offset_right = 648.0
+offset_bottom = 1152.0
+
+[node name="SubViewport" type="SubViewport" parent="SubViewportContainer" unique_id=1877292295]
+transparent_bg = true
+handle_input_locally = false
+size = Vector2i(400, 650)
+render_target_update_mode = 4
+
+[node name="Grid" parent="SubViewportContainer/SubViewport" unique_id=688690635 instance=ExtResource("2_5u05p")]
+visible = false
+offset_left = 97.0
+offset_top = 245.0
+offset_right = 97.0
+offset_bottom = 245.0
+
+[node name="SharpGridView" type="TextureRect" parent="." unique_id=701944746]
+material = SubResource("ShaderMaterial_cq453")
+offset_right = 648.0
+offset_bottom = 1152.0
+pivot_offset = Vector2(126, 120)
+mouse_filter = 2
+texture = SubResource("ViewportTexture_puvdw")
 
 [node name="Blackout" type="ColorRect" parent="." unique_id=1351278515]
 visible = false

--- a/game/level/level_template.tscn
+++ b/game/level/level_template.tscn
@@ -24,7 +24,7 @@ shader_parameter/vignette_softness = 0.350000016625
 [sub_resource type="ViewportTexture" id="ViewportTexture_puvdw"]
 viewport_path = NodePath("SubViewportContainer/SubViewport")
 
-[node name="LevelTemplate" type="Node2D" unique_id=1641894213 node_paths=PackedStringArray("winning_menu", "game_over_ui", "level_label", "level_manager", "blackout", "sub_viewport", "sub_viewport_container")]
+[node name="LevelTemplate" type="Node2D" unique_id=1641894213 node_paths=PackedStringArray("winning_menu", "game_over_ui", "level_label", "level_manager", "blackout", "sub_viewport", "sub_viewport_container", "camera")]
 script = ExtResource("1_pp25q")
 winning_menu = NodePath("WinningMenu")
 game_over_ui = NodePath("GameOverUI")
@@ -33,6 +33,7 @@ level_manager = NodePath("LevelManager")
 blackout = NodePath("Blackout")
 sub_viewport = NodePath("SubViewportContainer/SubViewport")
 sub_viewport_container = NodePath("SubViewportContainer")
+camera = NodePath("SubViewportContainer/SubViewport/Camera2D")
 
 [node name="SubViewportContainer" type="SubViewportContainer" parent="." unique_id=1308685668]
 material = SubResource("ShaderMaterial_puvdw")
@@ -51,6 +52,8 @@ offset_left = 97.0
 offset_top = 245.0
 offset_right = 97.0
 offset_bottom = 245.0
+
+[node name="Camera2D" type="Camera2D" parent="SubViewportContainer/SubViewport" unique_id=548771083 groups=["grid_camera"]]
 
 [node name="SharpGridView" type="TextureRect" parent="." unique_id=701944746]
 material = SubResource("ShaderMaterial_cq453")

--- a/game/level/sharp_grid.gdshader
+++ b/game/level/sharp_grid.gdshader
@@ -1,0 +1,12 @@
+shader_type canvas_item;
+
+uniform vec2 center = vec2(0.5, 0.5);
+uniform float vignette_radius : hint_range(0.0, 1.0) = 0.2;
+uniform float vignette_softness : hint_range(0.0, 1.0) = 0.5;
+
+void fragment() {
+    vec4 tex_color = texture(TEXTURE, UV);
+    float dist = distance(UV, center);
+    float alpha_factor = 1.0 - smoothstep(vignette_radius, vignette_radius + vignette_softness, dist);
+    COLOR = vec4(tex_color.rgb, tex_color.a * alpha_factor);
+}

--- a/game/level/sharp_grid.gdshader.uid
+++ b/game/level/sharp_grid.gdshader.uid
@@ -1,0 +1,1 @@
+uid://c05k3j03rqccv

--- a/project.godot
+++ b/project.godot
@@ -37,6 +37,10 @@ window/size/viewport_height=1152
 window/stretch/mode="viewport"
 window/handheld/orientation=1
 
+[input_devices]
+
+pointing/emulate_touch_from_mouse=true
+
 [physics]
 
 3d/physics_engine="Jolt Physics"

--- a/util/gestures/grid_gestures.gd
+++ b/util/gestures/grid_gestures.gd
@@ -1,0 +1,35 @@
+extends Node
+class_name GridGestures
+
+
+@export var camera: Camera2D
+@export var zoom_factor: float = 0.001
+@export var move_factor: float = 0.1
+
+var min_zoom := Vector2(0.2, 0.2)
+var max_zoom := Vector2(3.0, 3.0)
+var grid_init_pos: Vector2 # TODO when double tapping, reset grid position and scale
+
+
+func _ready() -> void:
+	camera = get_tree().get_first_node_in_group("grid_camera")
+	var extra_limit = Vector2(200, 500)
+	var screen_w = ProjectSettings.get_setting("display/window/size/viewport_width")
+	var screen_h = ProjectSettings.get_setting("display/window/size/viewport_height")
+	camera.position = Vector2(screen_w / 2.0, screen_h / 2.0)
+	camera.limit_left = -extra_limit.x * 2
+	camera.limit_top = -extra_limit.y * 2
+	camera.limit_right = screen_w + extra_limit.x
+	camera.limit_bottom = screen_h + extra_limit.y
+
+
+func _on_touch_gestures_drag_detected(dist_vec: Vector2) -> void:
+	camera.position -= dist_vec * move_factor
+
+
+func _on_touch_gestures_pinch_detected(dist_diff: float) -> void:
+	print("pinching! Lemme scale grid...")
+	var zoom_change = Vector2(dist_diff, dist_diff) * zoom_factor
+	var new_zoom = camera.zoom + zoom_change
+	new_zoom = clamp(new_zoom, min_zoom, max_zoom)
+	camera.zoom = new_zoom

--- a/util/gestures/grid_gestures.gd.uid
+++ b/util/gestures/grid_gestures.gd.uid
@@ -1,0 +1,1 @@
+uid://bpv8dvha8ck34

--- a/util/gestures/grid_gestures.tscn
+++ b/util/gestures/grid_gestures.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=3 uid="uid://cpwbaa6s4byvc"]
+
+[node name="GridGestures" type="Node2D" unique_id=2122793614]

--- a/util/gestures/touch_gestures.gd
+++ b/util/gestures/touch_gestures.gd
@@ -1,0 +1,52 @@
+extends Node2D
+class_name TouchGestures
+
+
+signal drag_detected(dist_vec: Vector2)
+signal pinch_detected(dist_diff: float)
+
+var touches := {}
+var drag_start_pos := Vector2.ZERO
+var pinch_start_dist := 0.0
+var is_dragging := false
+var is_pinching := false
+
+func _input(event: InputEvent) -> void:
+	if event is InputEventScreenTouch:
+		if event.pressed:
+			touches[event.index] = event.position
+		else:
+			touches.erase(event.index)
+		_evaluate_gesture_state()
+	elif event is InputEventScreenDrag:
+		touches[event.index] = event.position
+		_process_movement(event)
+		#queue_redraw()
+	#_draw_debug()
+
+func _evaluate_gesture_state() -> void:
+	is_dragging = false
+	is_pinching = false
+	match touches.size():
+		1:
+			is_dragging = true
+			drag_start_pos = touches.values()[0]
+		2:
+			is_pinching = true
+			pinch_start_dist = touches.values()[0].distance_to(touches.values()[1])
+
+
+func _process_movement(event: InputEvent) -> void:
+	if is_dragging and touches.size() == 1:
+		drag_detected.emit(event.relative)
+		
+	elif is_pinching and touches.size() == 2:
+		var curr_dist = touches.values()[0].distance_to(touches.values()[1])
+		var dist_diff = curr_dist - pinch_start_dist
+		pinch_detected.emit(dist_diff)
+		pinch_start_dist = curr_dist
+
+
+func _draw_debug() -> void:
+	for touch_position in touches.values():
+		draw_circle(touch_position, 100.0, Color.CORAL, false, 5.0)

--- a/util/gestures/touch_gestures.gd.uid
+++ b/util/gestures/touch_gestures.gd.uid
@@ -1,0 +1,1 @@
+uid://dee5ryb6km0hk

--- a/util/gestures/touch_gestures.tscn
+++ b/util/gestures/touch_gestures.tscn
@@ -1,0 +1,13 @@
+[gd_scene format=3 uid="uid://cxdg0yiumvkqb"]
+
+[ext_resource type="Script" uid="uid://dee5ryb6km0hk" path="res://util/gestures/touch_gestures.gd" id="1_oq0ut"]
+[ext_resource type="PackedScene" uid="uid://bqy1v2k8j2a25" path="res://util/signal_bus/signal_bus_sender.tscn" id="2_r0ed5"]
+
+[node name="TouchGestures" type="Node2D" unique_id=1720384620]
+script = ExtResource("1_oq0ut")
+
+[node name="SignalBusSender" parent="." unique_id=1721126377 instance=ExtResource("2_r0ed5")]
+signal_prefix = "touch_gestures_"
+
+[connection signal="drag_detected" from="." to="SignalBusSender" method="connect_signal"]
+[connection signal="pinch_detected" from="." to="SignalBusSender" method="connect_signal"]

--- a/util/signal_bus/signal_bus_receiver.gd
+++ b/util/signal_bus/signal_bus_receiver.gd
@@ -16,6 +16,10 @@ signal main_menu_play_pressed()
 signal level_manager_level_won()
 signal level_manager_level_lost()
 
+signal touch_gestures_pinch_detected(dist_diff: float)
+signal touch_gestures_drag_detected(dist_vec: Vector2)
+
+
 const GROUP := &'RECEIVER_GROUP'
 
 static var _s_dirty := true


### PR DESCRIPTION
This PR adds multi-touch gestures for `Grid`, as well as an API for touch gestures in general (the class `TouchGestures`).

The gestures implemented for `Grid` were:
- **zooming in/out** when pinching with two fingers
- **moving** a camera that renders the level's `Grid` when dragging with one finger

Furthermore, this PR also adds a blur effect to the `Grid`'s rendering when it extends outside the screen.